### PR TITLE
Fixed a subtle timing bug

### DIFF
--- a/arduino/waveform.ino
+++ b/arduino/waveform.ino
@@ -40,7 +40,7 @@ int getDigitalFromMillis(int relMillis)
     if (relMillis < 1000/16) {
         return 0;
     }
-    float periodMillis = 1000 / frequency;
+    float periodMillis = 1000.0 / frequency;
     int nCycles = relMillis / periodMillis;
     float normMillis = relMillis - nCycles * periodMillis;
     if (normMillis < periodMillis / 2) {


### PR DESCRIPTION
The period was being calculated as 62 instead of 62.5 due to integer division, meaning the waveform frequency was previously 16.13Hz.